### PR TITLE
Use childNodes rather than getElementsByTagName.

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,9 +4,9 @@
 	// return first element in scope containing case-sensitive text 
 	function getElementByText(scope, text) {
 		// iterate descendants of scope
-		for (var all = scope.getElementsByTagName('*'), index = 0, element; (element = all[index]); ++index) {
+		for (var all = scope.childNodes, index = 0, element; (element = all[index]); ++index) {
 			// conditionally return element containing visible, case-sensitive text (matched)
-			if ((element.innerText || element.textContent || '').indexOf(text) !== -1) {
+			if (element.nodeType == 1 && (element.innerText || element.textContent || '').indexOf(text) !== -1) {
 				return getElementByText(element, text);
 			}
 		}


### PR DESCRIPTION
getElementsByTagName() returns all descendants, which means it iterates over children of things you have already discounted. childNodes returns only the immediate children. I think this should be more efficient (jsperf has [a comparison](http://jsperf.com/childnodes-vs-getelementsbytagname-2) of getElementsByTagName/childNodes where the former is 50% slower, and that's just doing a simple lookup, no iteration).
