### PR TITLE
Add accessibility features

### DIFF
--- a/fragmention.js
+++ b/fragmention.js
@@ -46,6 +46,9 @@ if (!('fragmention' in window.location)) (function () {
 
 				// set fragmention attribute
 				element.setAttribute('fragmention', '');
+				element.setAttribute('tabindex', '0');
+				element.focus();
+
 
 				// DEPRECATED: trigger style in IE8
 				if (element.runtimeStyle) {


### PR DESCRIPTION
While a visual user is pointed at the right piece of text, non-visual & keyboard users are not and have to start at the beginning of the document.

Setting `element.setAttribute('tabindex', '0');` makes the element focusable, even if it is only a div or a paragraph, so we can `focus` the element easily. This also provides the opportunity to style the fragmention diffetently while it has the focus, using the `[fragmention]:focus` selector. 

(Note: I personally prefer to have the attribute as `data-fragmention`, using the HTML5 data attributes.)
